### PR TITLE
Never decrease island under the starting size

### DIFF
--- a/src/main/java/world/bentobox/boxed/AdvancementsManager.java
+++ b/src/main/java/world/bentobox/boxed/AdvancementsManager.java
@@ -151,7 +151,7 @@ public class AdvancementsManager {
      */
     public int checkIslandSize(Island island) {
         // Island is always a minimum of 1 for free.
-				int defaultSize = addon.getSettings().getIslandProtectionRange();
+        int defaultSize = addon.getSettings().getIslandProtectionRange();
         int shouldSize = getIsland(island).getAdvancements().stream().mapToInt(this::getScore).sum() + defaultSize;
         if (shouldSize < 1) {
             // Boxes can never be less than 1 in protection size

--- a/src/main/java/world/bentobox/boxed/AdvancementsManager.java
+++ b/src/main/java/world/bentobox/boxed/AdvancementsManager.java
@@ -151,7 +151,8 @@ public class AdvancementsManager {
      */
     public int checkIslandSize(Island island) {
         // Island is always a minimum of 1 for free.
-        int shouldSize = getIsland(island).getAdvancements().stream().mapToInt(this::getScore).sum() + 1;
+				int defaultSize = addon.getSettings().getIslandProtectionRange();
+        int shouldSize = getIsland(island).getAdvancements().stream().mapToInt(this::getScore).sum() + defaultSize;
         if (shouldSize < 1) {
             // Boxes can never be less than 1 in protection size
             return 0;


### PR DESCRIPTION
**Problem**
The starting protection range works but once `syncAdvancements` is called, the island will decrease to `1`

**Fix**
Getting the `IslandProtectionRange` and adding it to the `shouldSize` instead of adding `1`