### PR TITLE
Fix ALLOW_MOVE_BOX flag

### DIFF
--- a/src/main/java/world/bentobox/boxed/AdvancementsManager.java
+++ b/src/main/java/world/bentobox/boxed/AdvancementsManager.java
@@ -151,7 +151,7 @@ public class AdvancementsManager {
      */
     public int checkIslandSize(Island island) {
         // Island is always a minimum of 1 for free.
-				int defaultSize = addon.getSettings().getIslandProtectionRange();
+        int defaultSize = addon.getSettings().getIslandProtectionRange();
         int shouldSize = getIsland(island).getAdvancements().stream().mapToInt(this::getScore).sum() + defaultSize;
         if (shouldSize < 1) {
             // Boxes can never be less than 1 in protection size

--- a/src/main/java/world/bentobox/boxed/AdvancementsManager.java
+++ b/src/main/java/world/bentobox/boxed/AdvancementsManager.java
@@ -151,8 +151,7 @@ public class AdvancementsManager {
      */
     public int checkIslandSize(Island island) {
         // Island is always a minimum of 1 for free.
-        int defaultSize = addon.getSettings().getIslandProtectionRange();
-        int shouldSize = getIsland(island).getAdvancements().stream().mapToInt(this::getScore).sum() + defaultSize;
+        int shouldSize = getIsland(island).getAdvancements().stream().mapToInt(this::getScore).sum() + 1;
         if (shouldSize < 1) {
             // Boxes can never be less than 1 in protection size
             return 0;

--- a/src/main/java/world/bentobox/boxed/AdvancementsManager.java
+++ b/src/main/java/world/bentobox/boxed/AdvancementsManager.java
@@ -151,7 +151,8 @@ public class AdvancementsManager {
      */
     public int checkIslandSize(Island island) {
         // Island is always a minimum of 1 for free.
-        int shouldSize = getIsland(island).getAdvancements().stream().mapToInt(this::getScore).sum() + 1;
+				int defaultSize = addon.getSettings().getIslandProtectionRange();
+        int shouldSize = getIsland(island).getAdvancements().stream().mapToInt(this::getScore).sum() + defaultSize;
         if (shouldSize < 1) {
             // Boxes can never be less than 1 in protection size
             return 0;

--- a/src/main/java/world/bentobox/boxed/listeners/EnderPearlListener.java
+++ b/src/main/java/world/bentobox/boxed/listeners/EnderPearlListener.java
@@ -38,7 +38,8 @@ public class EnderPearlListener implements Listener {
     public void onEnderPearlLand(ProjectileHitEvent e) {
         if (!e.getEntityType().equals(EntityType.ENDER_PEARL)
                 || e.getHitBlock() == null
-                || !addon.inWorld(e.getHitBlock().getLocation())) {
+                || !addon.inWorld(e.getHitBlock().getLocation())
+								|| !Boxed.ALLOW_MOVE_BOX.isSetForWorld(addon.getOverWorld())) {
             return;
         }
         Location l = e.getHitBlock().getRelative(BlockFace.UP).getLocation();

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -1282,6 +1282,9 @@ boxed:
     minecraft:story/upgrade_tools: ''
 protection:
   flags:
+    ALLOW_MOVE_BOX:
+      name: Allow moving box
+      description: "&aBoxes can be moved\n&ausing EnderPearls\n"
     MOVE_BOX:
       name: Move Box
       description: "&b Toggle who can\n&b move the box with\n&b EnderPearls   \n"


### PR DESCRIPTION
Fixes #4 

The `ALLOW_MOVE_BOX` flag was never checked on event and `MOVE_BOX` was returning a false positive the event was always triggered.