### PR TITLE
Fixes crash when NetherWorld is disabeled

### DIFF
--- a/src/main/java/world/bentobox/boxed/listeners/AdvancementListener.java
+++ b/src/main/java/world/bentobox/boxed/listeners/AdvancementListener.java
@@ -194,7 +194,7 @@ public class AdvancementListener implements Listener {
      */
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onMove(PlayerMoveEvent e) {
-        if (!Util.sameWorld(e.getPlayer().getWorld(), addon.getNetherWorld())) {
+        if (!addon.getSettings().isNetherGenerate() || !Util.sameWorld(e.getPlayer().getWorld(), addon.getNetherWorld())) {
             return;
         }
         // Nether fortress advancement


### PR DESCRIPTION
Utils#sameWorld is not null-safe.
Add a check if nether world is enabled before running the other checks.